### PR TITLE
feat: expose tracker ready promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,16 @@ matomo.setUserId('user123');
 matomo.setUserId(null);
 ```
 
+### `ready`
+
+Promise that resolves after the tracker script loads and the initial page view is queued. It rejects when the script fails to load.
+
+**Example:**
+
+```javascript
+await matomo.ready;
+```
+
 ### `push(args)`
 
 Pushes any instruction directly to the Matomo tracker. This allows you to use any Matomo tracking method not explicitly exposed by this wrapper.

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,22 +141,23 @@ export function initMatomo(setupOptions: MatomoOptions) {
     window._paq.push(['setDomains', options.domains]);
   }
 
-  loadScript(scriptUrl, options.crossOrigin, options.trackerScriptDisable)
+  const ready = loadScript(scriptUrl, options.crossOrigin, options.trackerScriptDisable)
     .then(() => {
       // On initial page load, track the first page view
       if (options.enableLinkTracking) {
         window._paq.push(['enableLinkTracking']);
       }
       trackPageView();
-    })
-    .catch((error) => {
-      if (error.target) {
-        return console.error(
-          `An error occurred trying to load ${error.target.src}. `
-        );
-      }
-      console.error(error);
     });
+
+  ready.catch((error) => {
+    if (error.target) {
+      return console.error(
+        `An error occurred trying to load ${error.target.src}. `
+      );
+    }
+    console.error(error);
+  });
 
   /**
    * Tracks a custom event.
@@ -267,6 +268,7 @@ export function initMatomo(setupOptions: MatomoOptions) {
     trackEvent,
     trackPageView,
     setUserId,
-    push
+    push,
+    ready
   };
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,6 +32,7 @@ describe('matomo', () => {
     expect(matomo.trackPageView).toBeInstanceOf(Function);
     expect(matomo.trackEvent).toBeInstanceOf(Function);
     expect(matomo.push).toBeInstanceOf(Function);
+    expect(matomo.ready).toBeInstanceOf(Promise);
   });
 
   it('trackPageView should push correct data to _paq', () => {
@@ -53,6 +54,17 @@ describe('matomo', () => {
     matomo.trackEvent('Category', 'Action', 'Name', 10);
 
     expect(window._paq).toContainEqual(['trackEvent', 'Category', 'Action', 'Name', 10]);
+  });
+
+  it('ready should resolve when script loading is disabled', async () => {
+    const matomo = initMatomo({
+      host: 'https://example.com',
+      siteId: 1,
+      trackerScriptDisable: true,
+    });
+
+    await expect(matomo.ready).resolves.toBeUndefined();
+    expect(window._paq).toContainEqual(['trackPageView']);
   });
 
   it('push should push arguments to _paq', () => {


### PR DESCRIPTION
Return a ready promise so callers can wait for tracker script initialization.