### PR TITLE
refactor: type Matomo commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The `initMatomo` function accepts a configuration object with the following opti
 | `cookieDomain` | `string` | `''` | Set the cookie domain for cross-subdomain tracking, `window._paq.push(['setCookieDomain', options.cookieDomain])` |
 | `domains` | `string[]` | `[]` | List of domains to track as internal (for cross-domain tracking), `window._paq.push(['setDomains', options.domains])` |
 | `crossOrigin` | `'anonymous' \| 'use-credentials'` | `undefined` | Cross-origin attribute for the tracker script |
-| `preInitActions` | `any[]` | `[]` | Array of Matomo commands to execute before initialization |
+| `preInitActions` | `MatomoCommand[]` | `[]` | Array of Matomo commands to execute before initialization |
 | `trackRouter` | `boolean` | `false` | Automatically track SPA page changes via history API monitoring |
 
 ### Example with All Options

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
+export type MatomoCommand = [methodName: string, ...parameters: unknown[]];
+
+type MatomoOptionsWithDefaults = Omit<Required<MatomoOptions>, 'crossOrigin'> & {
+  crossOrigin?: MatomoOptions['crossOrigin'];
+};
+
 export interface MatomoOptions {
   host: string;
   siteId: number | string;
@@ -15,7 +21,7 @@ export interface MatomoOptions {
   cookieDomain?: string;
   domains?: string[];
   crossOrigin?: 'anonymous' | 'use-credentials';
-  preInitActions?: any[];
+  preInitActions?: MatomoCommand[];
   trackRouter?: boolean;
 }
 
@@ -28,7 +34,7 @@ export type MatomoTracker = ReturnType<typeof initMatomo>;
 
 declare global {
   interface Window {
-    _paq: any[][];
+    _paq: MatomoCommand[];
   }
 }
 
@@ -82,7 +88,7 @@ export function initMatomo(setupOptions: MatomoOptions) {
   }
 
   previousUrl = window.location.href;
-  const options: Required<MatomoOptions> = {
+  const options: MatomoOptionsWithDefaults = {
     trackerFileName: 'matomo',
     enableLinkTracking: true,
     preInitActions: [],
@@ -98,7 +104,7 @@ export function initMatomo(setupOptions: MatomoOptions) {
     heartBeatTimerInterval: 15,
     cookieDomain: '',
     domains: [],
-    crossOrigin: undefined as any,
+    crossOrigin: undefined,
     ...setupOptions
   };
 
@@ -224,7 +230,7 @@ export function initMatomo(setupOptions: MatomoOptions) {
    * @param args - The instruction to push.
    * @see https://developer.matomo.org/guides/tracking-javascript-guide
    */
-  function push(args: any[]): void {
+  function push(args: MatomoCommand): void {
     window._paq.push(args);
   }
 


### PR DESCRIPTION
Replace public any command types with an exported MatomoCommand tuple type.