### PR TITLE
fix: normalize Matomo host URLs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,10 @@ let previousUrl: string;
  * @param trackerScriptDisable - If set, the tracker script will not be loaded, eg. if you already have it loaded in your application.
  * @returns Promise that resolves when the script is loaded
  */
+function normalizeHost(host: string): string {
+  return host.replace(/\/+$/, '');
+}
+
 function loadScript(
   trackerScript: string, 
   crossOrigin?: 'anonymous' | 'use-credentials', 
@@ -102,7 +106,8 @@ export function initMatomo(setupOptions: MatomoOptions) {
     ...setupOptions
   };
 
-  const { host, siteId, trackerFileName, trackerUrl, trackerScriptUrl } = options;
+  const { siteId, trackerFileName, trackerUrl, trackerScriptUrl } = options;
+  const host = normalizeHost(options.host);
   const scriptUrl = trackerScriptUrl || `${host}/${trackerFileName}.js`;
   const endpointUrl = trackerUrl || `${host}/${trackerFileName}.php`;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,6 +34,16 @@ describe('matomo', () => {
     expect(matomo.push).toBeInstanceOf(Function);
   });
 
+  it('should normalize host when building tracker URLs', () => {
+    initMatomo({
+      host: 'https://example.com/',
+      siteId: 1,
+    });
+
+    expect(window._paq).toContainEqual(['setTrackerUrl', 'https://example.com/matomo.php']);
+    expect(document.querySelector('script[src="https://example.com/matomo.js"]')).toBeDefined();
+  });
+
   it('trackPageView should push correct data to _paq', () => {
     const matomo = initMatomo({
       host: 'https://example.com',


### PR DESCRIPTION
Strip trailing slashes from the Matomo host before building tracker URLs.